### PR TITLE
Makefile und Dockerfile hinzugefügt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM rocker/binder:latest
+
+## Declares build arguments
+ARG NB_USER
+ARG NB_UID
+
+## Installs additional software and needed LaTeX packages
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends xsltproc texlive-lang-german
+RUN tlmgr install csquotes amsmath eurosym mathspec fontspec upquote microtype geometry hyperref polyglossia natbib biblatex fancyvrb booktabs grffile ulem parskip bidi fancyhdr caption infwarerr babel-german newfloat epstopdf epstopdf-pkg
+
+## Copies your repo files into the Docker Container
+COPY . ${HOME}
+RUN chown -R ${NB_USER} ${HOME}
+
+## Become normal user again
+USER ${NB_USER}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends xsltproc texliv
 RUN tlmgr install csquotes amsmath eurosym mathspec fontspec upquote microtype geometry hyperref polyglossia natbib biblatex fancyvrb booktabs grffile ulem parskip bidi fancyhdr caption infwarerr babel-german newfloat epstopdf epstopdf-pkg
 
 ## Copies your repo files into the Docker Container
-COPY . ${HOME}
-RUN chown -R ${NB_USER} ${HOME}
+COPY . /home/rstudio
+RUN chown -R ${NB_USER} /home/rstudio
 
 ## Become normal user again
 USER ${NB_USER}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,49 @@
+# Makefile for creating the galleys PDF, HTML, EPUB 
+# of articles in Informationspraxis with Pandoc
+# 
+# You can creates either (1) all article galleys from all the docx and odt
+# files in this directory, or (2) make a specific galley (recognized by
+# the file ending) from a specific article only
+# (1) make
+# (2) make article.pdf
+#
+
+SOURCE_DOCS := $(wildcard *.docx *.odt)
+SOURCE_DOCS_NORMALIZED := $(SOURCE_DOCS:.odt=.docx)
+EXPORTED=\
+ $(SOURCE_DOCS_NORMALIZED:.docx=.md) \
+ $(SOURCE_DOCS_NORMALIZED:.docx=.yml) \
+ $(SOURCE_DOCS_NORMALIZED:.docx=.pdf) \
+ $(SOURCE_DOCS_NORMALIZED:.docx=.html) \
+ $(SOURCE_DOCS_NORMALIZED:.docx=.epub)
+
+.PHONY: all
+all : $(EXPORTED)
+
+# Create Markdown file from either Microsoft or LibreOffice document
+%.md: %.docx
+	pandoc --extract-media . --wrap=none -t markdown-simple_tables -o $@ $^
+%.md: %.odt
+	pandoc --extract-media . --wrap=none -t markdown-simple_tables -o $@ $^
+
+# Create YAML file with metadata
+#
+# TODO reconsider this option
+#%.yml: %.xml
+#	xsltproc xml-to-yaml.xslt $^ > $@
+#
+# alternative when there is no xml file
+%.yml: %.md
+	cp vorlage-metadaten.yml $@
+
+# Create all the ouput formats from the md files
+%.html: %.md %.yml
+	pandoc -s --toc --template pandoc-template.html -o $@ $^
+%.pdf: %.md %.yml
+	pandoc -s --toc --template pandoc-template.tex -V fontsize=12pt -V papersize=a4paper -V documentclass=article -V headheight=20mm -V headsep=10mm -V footskip=20mm -V top=30mm -V bottom=40mm -V left=25mm -V right=25mm -V graphics=1 -o $@ $^
+%.epub: %.md %.yml
+	pandoc -s --toc -o $@ $^
+
+# For debugging
+%.tex: %.md %.yml
+	pandoc -s --toc --template pandoc-template.tex -V fontsize=12pt -V papersize=a4paper -V documentclass=article -V headheight=20mm -V headsep=10mm -V footskip=20mm -V top=30mm -V bottom=40mm -V left=25mm -V right=25mm -V graphics=1 -o $@ $^

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Informationspraxis/artikel-vorlage/master?filepath=README.md&urlpath=rstudio)
+
 Dieses Repository enthält Vorlagen für Artikel der Fachzeitschrift [Informationspraxis](http://informationspraxis.de/) sowie Konfigurationsdateien zur Konvertierung der Artikel mit [Pandoc](https://pandoc.org) nach HTML, PDF und EPUB.
 
 ## Vorlage für Beitragseinreichungen


### PR DESCRIPTION
Mit dem Makefile können die entsprechenden Kommandos lokal einfach aufgerufen werden. Man muss lediglich ein Word- oder LibreOffice-Dokument in das Verzeichnis kopieren und kann dann auf der Kommandozeile einfach `make` eingeben. Wenn man mehrere Dateien haten, dann werden alle Galleys und MD als Zwischenschritt generiert. Bei Änderungen der MD-Datei kann dann einfach wieder mit einem erneuten `make` die Erzeugung der Fahnen angestossen werden. Einzelne Ausgabeformat können auch etwa mit `make artikel.pdf` angestossen werden.

Das Dockerfile setzt auf dem Docker für R inklusive Pandoc, TexLive und R-Studio auf. Über Binder  kann man dies auch direkt im Browser starten und hat damit eine lauffähige Umgebung zum Erzeugen der Fahnen ohne lokale Installation. Auch wenn man viele Funktionen von R-Studio nicht benötigt, lassen sich dort auch Dateien hochladen sowie Textdateien bearbeiten und Kommandos (wie etwa `make`) in einem Terminal aufrufen. Zum Ausprobieren kann man aktuell diesen Link verwenden: https://mybinder.org/v2/gh/zuphilip/artikel-vorlage/make?filepath=README.md&urlpath=rstudio