### PR TITLE
Lua Filter für kompakte Listen + Bilder ohne Dimensionsangaben

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,9 @@ all : $(EXPORTED)
 
 # Create Markdown file from either Microsoft or LibreOffice document
 %.md: %.docx
-	pandoc --extract-media . --wrap=none -t markdown-simple_tables -o $@ $^
+	pandoc --extract-media . --wrap=none --lua-filter clean-images.lua --lua-filter compact-lists.lua -t markdown-simple_tables -o $@ $^
 %.md: %.odt
-	pandoc --extract-media . --wrap=none -t markdown-simple_tables -o $@ $^
+	pandoc --extract-media . --wrap=none --lua-filter clean-images.lua --lua-filter compact-lists.lua -t markdown-simple_tables -o $@ $^
 
 # Create YAML file with metadata
 #
@@ -47,3 +47,7 @@ all : $(EXPORTED)
 # For debugging
 %.tex: %.md %.yml
 	pandoc -s --toc --template pandoc-template.tex -V fontsize=12pt -V papersize=a4paper -V documentclass=article -V headheight=20mm -V headsep=10mm -V footskip=20mm -V top=30mm -V bottom=40mm -V left=25mm -V right=25mm -V graphics=1 -o $@ $^
+%.native.txt: %.docx
+	pandoc --extract-media . --wrap=none --lua-filter clean-images.lua --lua-filter compact-lists.lua -t native -o $@ $^
+%.native.txt: %.odt
+	pandoc --extract-media . --wrap=none --lua-filter clean-images.lua --lua-filter compact-lists.lua -t native -o $@ $^

--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ Legen Sie das eingereichte Dokument ebenfalls in diesem Verzeichnis ab. In diese
 - von Format DOCX (Beispiel für Quelldatei `erstautorin-2019.docx`)
 
 ```
-pandoc --extract-media . --wrap=none -t markdown-simple_tables -o erstautorin-2019.md erstautorin-2019.docx
+pandoc --extract-media . --wrap=none --lua-filter clean-images.lua --lua-filter compact-lists.lua -t markdown-simple_tables -o erstautorin-2019.md erstautorin-2019.docx
 ```
 
 - von Format ODT (Beispiel für Quelldatei `erstautorin-2019.odt`)
 
 ```
-pandoc --extract-media . --wrap=none -t markdown-simple_tables -o erstautorin-2019.md erstautorin-2019.odt
+pandoc --extract-media . --wrap=none --lua-filter clean-images.lua --lua-filter compact-lists.lua -t markdown-simple_tables -o erstautorin-2019.md erstautorin-2019.odt
 ```
 
 #### Schritt 3: Nachbearbeitung der Markdown-Datei
@@ -90,9 +90,8 @@ Die im vorigen Schritt erstellte Markdown-Datei in einem Markdown-Editor (z.B. T
 Folgende Nacharbeiten sind erforderlich:
 
 * Metadaten und Fragmente aus der Vorlage zu Beginn der Datei löschen. Der Text muss direkt mit der ersten Überschrift (z.B. `1 Einleitung`) beginnen.
-* Prüfen, ob alle Bilder korrekt angezeigt werden. Größenangaben wie `{width="6.531496062992126in" height="2.263779527559055in"}` löschen.
+* Prüfen, ob alle Bilder korrekt angezeigt werden.
 * Bildunterschriften prüfen und ggf. vereinheitlichen.
-* Wenn Listen kompakt dargestellt werden sollen, dann im Quellcode (Menü Darstellung / Quellcodemodus) leere Zeilen innerhalb der Aufzählungen entfernen.
 * Ggf. weitere Formatierung gemäß der [Richtlinien](https://journals.ub.uni-heidelberg.de/index.php/ip/about/submissions) und nach [Pandoc-Markdown-Syntax](http://pandoc.org/MANUAL.html#pandocs-markdown)
 
 ### HTML, PDF und EPUB generieren

--- a/clean-images.lua
+++ b/clean-images.lua
@@ -1,0 +1,6 @@
+function Image (elem)
+	-- delete the width and height attributes
+	elem.attributes.width = nil
+	elem.attributes.height = nil
+	return elem
+end

--- a/compact-lists.lua
+++ b/compact-lists.lua
@@ -1,0 +1,29 @@
+-- Source: https://stackoverflow.com/questions/57940840/pandoc-lua-filter-to-force-compact-lists
+
+-- Iterate over all blocks in an item, converting 'top-level'
+-- Para into Plain blocks.
+function compactifyItem (blocks)
+  -- step through the list of blocks step-by-step, keeping track of the
+  -- element's index in the list in variable `i`, and assign the current
+  -- block to `blk`.
+  -- 
+  for i, blk in ipairs(blocks) do
+    if blk.t == 'Para' then
+      -- update in item's block list.
+      blocks[i] = pandoc.Plain(blk.content)
+    end
+  end
+  return blocks
+end
+
+function compactifyList (l)
+  -- l.content is an instance of pandoc.List, so the following is equivalent
+  -- to pandoc.List.map(l.content, compactifyItem)
+  l.content = l.content:map(compactifyItem)
+  return l
+end
+
+return {{
+  BulletList = compactifyList,
+  OrderedList = compactifyList
+}}


### PR DESCRIPTION
Vorher sind Listen wie folgt ausgegeben worden:
```md
- A

- B

- c
```
Mit dem Filter wird dies kompakter zu
```
- A
- B
- C
```
Funktioniert auch für verschachtelte Listen.

Vorher sind Bilder wir folgt ausgegeben worden
```md
![](./media/image5.png){width="6.323611111111111in" height="2.76875in"}
```
Mit dem Filter werden die Dimensionsangaben weggelassen:
```md
![](./media/image5.png)
```